### PR TITLE
Keep footer at the bottom of any page always

### DIFF
--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -7,7 +7,7 @@ import { Footer } from "../components/Footer"
 export const Layout = () => {
     return (
         <ScrollToTop>
-            <div className="d-flex flex-column" style={{height: '100vh'}}>
+            <div className="d-flex flex-column" style={{minHeight: '100vh'}}>
                 <Navbar />
                     <Outlet />
                 <Footer />

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -7,9 +7,11 @@ import { Footer } from "../components/Footer"
 export const Layout = () => {
     return (
         <ScrollToTop>
-            <Navbar />
-                <Outlet />
-            <Footer />
+            <div className="d-flex flex-column" style={{height: '100vh'}}>
+                <Navbar />
+                    <Outlet />
+                <Footer />
+            </div>
         </ScrollToTop>
     )
 }


### PR DESCRIPTION
Currently the footer is not staying at the bottom of the page. This is because some pages do not occupy 100% of the viewport.

In those scenarios, the code below ensures the footer stays at the bottom even if the content of the page does not take the whole viewport.